### PR TITLE
Fix datetime regex

### DIFF
--- a/src/controllers/validation.json
+++ b/src/controllers/validation.json
@@ -10,7 +10,7 @@
                         "$ref": "tempOutfitterApplicantInfo"
                     },
                     "type": {
-                        "type": "string", 
+                        "type": "string",
                         "default": "tempOutfitters",
                         "enum":[
                             "noncommercial",
@@ -282,14 +282,14 @@
             "startDateTime": {
                 "default":"",
                 "fromIntake":true,
-                "pattern":"^(19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T(0\\d|1\\d|2[0-3]):([0-5]\\d):([0-5]\\d)Z$",
+                "pattern":"\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)",
                 "store":["middleLayer:startDatetime"],
                 "type": "string"
             },
             "endDateTime": {
                 "default":"",
                 "fromIntake":true,
-                "pattern":"^(19|20)\\d\\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T(0\\d|1\\d|2[0-3]):([0-5]\\d):([0-5]\\d)Z$",
+                "pattern":"\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)",
                 "store":["middleLayer:endDatetime"],
                 "type": "string"
             },
@@ -394,7 +394,7 @@
                     "function":"concat"
                 },
                 "store":["basic:/application"],
-                "type":"string"  
+                "type":"string"
             }
         },
         "required": ["activityDescription", "locationDescription", "startDateTime", "endDateTime", "numberParticipants"]
@@ -403,7 +403,7 @@
         "id": "/phoneNumber",
         "type": "object",
         "properties": {
-            "areaCode": { 
+            "areaCode": {
                 "basicField":"areaCode",
                 "default":"0",
                 "fromIntake":true,


### PR DESCRIPTION
Update datetime regex in `src/controllers/validation.json` to match the one here, https://github.com/flexion/fs-intake-module/blob/sprint-11-development/server/util.es6#L35, which essentially matches ISO 8601 extended.

Closes #42