### PR TITLE
Add Open Forest ID/intakeId field

### DIFF
--- a/dba/migrations/11-add-application-id-to-purpose-fields.js
+++ b/dba/migrations/11-add-application-id-to-purpose-fields.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+	up: function (queryInterface, Sequelize) {
+		return queryInterface.addColumn('applications', 'intake_id', {
+  			type: Sequelize.STRING(255)
+		});
+	},
+
+	down: function (queryInterface, Sequelize) {
+		return queryInterface.removeColumn('applications', 'intake_id');
+	}
+};

--- a/src/api.json
+++ b/src/api.json
@@ -67,6 +67,7 @@
       "get": {
         "x-mockOutput":"test/data/basicGET.json",
         "x-getTemplate":{
+          "intakeId":{"default":"", "intake":"middleLayer/intakeId"},
           "controlNumber":{"default":"", "intake":"accinstCn"},
           "region": {"default":"", "intake":"middleLayer/region"},
           "forest": {"default":"", "intake":"middleLayer/forest"},
@@ -209,6 +210,7 @@
       "get": {
         "x-mockOutput":"test/data/basicGET.json",
         "x-getTemplate":{
+          "intakeId":{"default":"", "intake":"middleLayer/intakeId"},
           "controlNumber":{"default":"", "intake":"accinstCn"},
           "region": {"default":"", "intake":"middleLayer/region"},
           "forest": {"default":"", "intake":"middleLayer/forest"},
@@ -626,6 +628,7 @@
     "noncommercialPermit": {
       "type": "object",
       "properties": {
+        "intakeId": { "type" : "string" },
         "region": { "type" : "string" },
         "forest": { "type" : "string" },
         "district": { "type" : "string" },
@@ -654,6 +657,7 @@
     "noncommercialPermitGet": {
       "type": "object",
       "properties": {
+        "intakeId": { "type": "string" },
         "controlNumber": {"type": "integer"},
         "region": { "type" : "string" },
         "forest": { "type" : "string" },
@@ -682,6 +686,7 @@
     "tempOutfitterPermit": {
       "type": "object",
        "properties": {
+        "intakeId": { "type" : "string" },
         "region": { "type" : "string" },
         "forest": { "type" : "string" },
         "district": { "type" : "string" },
@@ -710,6 +715,7 @@
     "tempOutfitterPermitGet": {
       "type": "object",
        "properties": {
+        "intakeId": { "type": "integer"},
         "controlNumber": { "type": "integer"},
         "region": { "type" : "string" },
         "forest": { "type" : "string" },

--- a/src/controllers/translate.json
+++ b/src/controllers/translate.json
@@ -92,13 +92,39 @@
             },
             "activityDescription": {
                 "default":"",
-                "sudsField": "purpose",
-                "fromIntake":true,
+                "fromIntake": true,
                 "localStore":true,
-                "type": "string",
+                "type": "string"
+            },
+            "purpose": {
+                "sudsField": "purpose",
+                "default": "",
+                "fromIntake": false,
+                "madeOf": {
+                    "fields": [
+                        {
+                            "fromIntake": false,
+                            "value": "ID on Open Forest platform: "
+                        },
+                        {
+                            "fromIntake": true,
+                            "field": "intakeId"
+                        },
+                        {
+                            "fromIntake": false,
+                            "value": ". \n"
+                        },
+                        {
+                            "fromIntake": true,
+                            "field": "tempOutfitterFields.activityDescription"
+                        }
+                    ],
+                    "function": "concat"
+                },
                 "sudsEndpoint": [
                     "/application"
-                ]                
+                ], 
+                "type": "string"
             },
             "advertisingURL": {
                 "default":"",
@@ -345,7 +371,15 @@
                     "fields":[
                         {
                             "fromIntake":false,
-                            "value":"Activity Description: "
+                            "value":"ID on Open Forest platform: "
+                        },
+                        {
+                            "fromIntake":true,
+                            "field":"intakeId"
+                        },
+                        {
+                            "fromIntake":false,
+                            "value":". \n Activity Description: "
                         },
                         {
                             "fromIntake":true,
@@ -529,6 +563,12 @@
         "id":"/commonFields",
         "type":"object",
         "properties":{
+            "intakeId": {
+                "default":"",
+                "fromIntake":true,
+                "localStore":true,
+                "type" : "string"
+            },
             "region": {
                 "default":"",
                 "fromIntake":true,
@@ -618,7 +658,7 @@
                     "fields":[
                         {
                             "fromIntake":false,
-                            "field" : "EP-"
+                            "value" : "EP-"
                         },
                         {
                             "fromIntake":true,
@@ -627,9 +667,17 @@
                         {
                             "fromIntake":true,
                             "field":"forest"
+                        },
+                        {
+                            "fromIntake":false,
+                            "value" : "-"
+                        },
+                        {
+                            "fromIntake":true,
+                            "field":"intakeId"
                         }
                     ],
-                    "function":"ePermitId"
+                    "function":"concat"
                 },
                 "sudsEndpoint":["/application"],
                 "type" : "string"

--- a/src/models/applications.js
+++ b/src/models/applications.js
@@ -21,7 +21,8 @@ module.exports = function(sequelize, DataTypes) {
 		experienceList: { type: DataTypes.STRING(512), field: 'experience_list' },
 		createdAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW, field: 'created' },
 		updatedAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW, field: 'updated' },
-		numberSpectators: { type: DataTypes.INTEGER, field: 'number_spectators' }
+		numberSpectators: { type: DataTypes.INTEGER, field: 'number_spectators' },
+		intakeId: { type: DataTypes.STRING(255), field: 'intake_id' }
 	}, {
 		timestamps  : true
 	}, {

--- a/test/data/testInputNoncommercial.json
+++ b/test/data/testInputNoncommercial.json
@@ -1,4 +1,5 @@
 {
+    "intakeId": "90",
     "region": "31",
     "forest": "50",
     "district": "50",

--- a/test/data/testInputTempOutfitters.json
+++ b/test/data/testInputTempOutfitters.json
@@ -1,4 +1,5 @@
 {
+    "intakeId": "90",
     "region": "38",
     "forest": "50",
     "district": "50",

--- a/test/noncommercial.js
+++ b/test/noncommercial.js
@@ -141,12 +141,25 @@ describe('Integration tests - noncommercial', function(){
 
 	});
 
-	it('should return valid json for noncommercial GET request for id', function(done) {
+	it('should return valid json for noncommercial GET request by control number', function(done) {
 
 		request(server)
 			.get(`${testURL}${postControlNumber}/`)
 			.set('x-access-token', token)
 			.expect('Content-Type', /json/)
+			.expect(200, done);
+
+	});
+
+	it('should return an intakeId field in the json for noncommercial GET request by control number', function(done) {
+
+		request(server)
+			.get(`${testURL}${postControlNumber}/`)
+			.set('x-access-token', token)
+			.expect('Content-Type', /json/)
+            .expect(function (res) {
+                expect(res.body.intakeId).to.equal('90');
+            })
 			.expect(200, done);
 
 	});

--- a/test/outfitters.js
+++ b/test/outfitters.js
@@ -256,6 +256,17 @@ describe('API Routes: permits/special-uses/commercial/outfitters', function() {
 
 		});
 
+		it('should return intakeId in json when getting outfitters permit using the controlNumber returned from POST', function(done) {
+
+			request(server)
+			.get(`${testURL}${postControlNumber}/`)
+			.set('x-access-token', token)
+			.expect(function(res){
+                expect(res.body.intakeId).to.equal('90');
+            })
+			.expect(200, done);
+		});
+
 		it('should return valid file when getting outfitters files using the controlNumber and fileName returned from POST', function(done) {
 			const getObjSpy = sinon.spy();
 			const postFileName = 'insuranceCertificate.doc';

--- a/test/post-translation-test.js
+++ b/test/post-translation-test.js
@@ -208,12 +208,15 @@ describe('Tests that the following object field objects were populated properly'
 				'activityDescription': descr
 			}
 		});
+		const expected = [
+            'ID on Open Forest platform: 90.',
+            'Five friends go to a cabin in the woods. Bad things happen.'
+        ].join(' \n');
 		const result = wrapSudsPrep(body, {}, true);
-		expect(result['/application'].purpose).to.eql(descr);
+		expect(result['/application'].purpose).to.eql(expected);
 	});
 	
 	it('populate a nested field fromIntake:true', function () {
-		// TODO: Depends on verified details for prior test.
 		const body = tempOutfitterFactory.create({});
 		const result = wrapSudsPrep(body, {}, true);
 		expect(result['/contact/phone'].areaCode).to.eql('202');
@@ -227,15 +230,19 @@ describe('Tests that the following object field objects were populated properly'
 			}
 		});
 		const result = wrapSudsPrep(body, {}, true);
-		expect(result['/application'].purpose).to.eql(descr);
+		const expected = [
+            'ID on Open Forest platform: 90.',
+            'Rename me rename me rename me.'
+        ].join(' \n');
+		expect(result['/application'].purpose).to.eql(expected);
 
 	});
 
-	it('add line breaks to a field with "linebreak" in the body ', function(){
+	it('generates the purpose field correctly and adds line breaks to a field with "linebreak" in the body ', function(){
 		const body = noncommercialFactory.create();
-
 		const result = wrapSudsPrep(body, noncommercialSchema, true);
 		const expected = [
+            'ID on Open Forest platform: 90.',
 			'Activity Description: PROVIDING WHITEWATER OUTFITTING AND GUIDING ACTIVITIES ON NATIONAL FOREST LANDS.',
 			'Location Description: string.',
 			'Start Date Time: 2013-01-12T12:00:00Z.',
@@ -244,6 +251,12 @@ describe('Tests that the following object field objects were populated properly'
 			'Number Spectators: .'
 		].join(' \n ');
 		expect(result['/application'].purpose).to.eql(expected);
+	});
+
+	it('populates ePermitId correctly', function () {
+		const body = tempOutfitterFactory.create({});
+		const result = wrapSudsPrep(body, {}, true);
+		expect(result['/application'].epermitId).to.eql('EP-3850-90');
 	});
 });
 


### PR DESCRIPTION
Users must refer
To applications somehow
Give them an ID.

- Add Open Forest ID/intakeId to middle layer database.
- Add intakeId to purpose field for both tempOutfitters and noncommercial permits.
- Change composition of `epermitId` field to use `intakeId`.
- Add tests for the above.

IntakeId is referred to as “Open Forest platform ID” in the purpose field for tempOutfitters and noncommercial applications.

This PR addresses https://github.com/18F/fs-middlelayer-api/issues/37 and is also part of https://github.com/18F/fs-permit-platform/issues/153.