### PR TITLE
Restrict contId to be 30 characters or less

### DIFF
--- a/src/controllers/sudsconnection/populateFields.js
+++ b/src/controllers/sudsconnection/populateFields.js
@@ -81,7 +81,7 @@ function getFieldFromBody(path, body){
  */
 function contId(person, fieldMakeUp) {
 	const fields = person ? fieldMakeUp.slice(0, 3) : fieldMakeUp.slice(-1);
-	return upperCaseJoin(fields);
+	return upperCaseJoin(fields).slice(0,30);
 }
 
 /**

--- a/test/post-translation-test.js
+++ b/test/post-translation-test.js
@@ -170,6 +170,36 @@ describe('Tests that the following object field objects were populated properly'
 		});
 	});
 
+	it('correctly builds a contID for an individual with a long name', function(){
+		const usher = [
+			'During the whole of a dull, dark, and soundless day in the autumn of the year',
+			'when the clouds hung oppressively low in the heavens, I had been passing alone',
+			'on horseback, through a singularly dreary tract of country; and at length found myself',
+			'as the shades of the evening drew on, within view of the melancholy House of Usher.'
+		].join(', ');
+		const sleep = [
+			'It was about eleven o’clock in the morning, mid October, with the sun not shining',
+			'and a look of hard wet rain in the clearness of the foothills. I was wearing my',
+			'powder-blue suit, with dark blue shirt, tie and display handkerchief, black brogues',
+			', black wool socks with dark blue clocks on them.',
+			'I was neat, clean, shaved and sober, and I didn’t care who knew it.'
+		].join('');
+
+		const body = tempOutfitterFactory.create({
+			'applicantInfo': {
+				'firstName': usher,
+				'lastName': sleep
+			}
+		});
+		expect(expected);
+		const result = wrapSudsPrep(body, {}, true);
+		expect(result['/contact/person']).to.eql({
+			'contId': 'IT WAS ABOUT ELEVEN O’CLOCK IN',
+			'firstName': usher,
+			'lastName': sleep
+		});
+	});
+
 	it('correctly builds a contID for an individual with an org name present', function(){
 		const body = tempOutfitterFactory.create({
 			'applicantInfo': {
@@ -196,9 +226,30 @@ describe('Tests that the following object field objects were populated properly'
 				'orgType': 'Association'
 			}
 		});
-		expect(expected);
 		const result = wrapSudsPrep(body, {}, false);
 		expect(result['/contact/organization'].contId).to.eql('RAYMIFASOLATIDOE');
+	});
+
+	it('correctly builds a contID for an organization with a long name', function(){
+		// TODO: Enable this test when we verify what the contId for an organization should be; code and schema make it look like it might be either the same as for an individual (which is a little odd) or the organization type (which would be very odd).
+        const dispossessed = [
+            'There was a wall. It did not look important. It was built of uncut rocks roughly mortared',
+            'An adult could look right over it, and even a child could climb it',
+            'Where it crossed the roadway, instead of having a gate it degenerated into mere geometry, a line, an idea of boundary',
+            'But the idea was real. It was important',
+            'For seven generations there had been nothing in the world more important than that wall.'
+        ].join('. ');
+		const body = tempOutfitterFactory.create({
+			'applicantInfo': {
+				'firstName': 'John',
+				'lastName': 'Doe',
+				'organizationName': dispossessed,
+				'orgType': 'Association'
+			}
+		});
+		expect(expected);
+		const result = wrapSudsPrep(body, {}, false);
+		expect(result['/contact/organization'].contId).to.eql('THERE WAS A WALL. IT DID NOT L');
 
 	});
 


### PR DESCRIPTION
Polonius knew
The soul of wit: brevity.
Now we know it too.

SUDS can't handle `contId` values longer than 30 characters, so when constructing them we should limit them to be that short or shorter.
